### PR TITLE
Adds sorting of projects

### DIFF
--- a/app/source/components/projects/projects.jsx
+++ b/app/source/components/projects/projects.jsx
@@ -12,7 +12,15 @@ class Projects extends React.Component {
 
   componentDidMount() {
     firebase.onProjectUpdate(projects => {
-      this.setState({ projects });
+      const sortedProjects = projects.sort((a, b) => {
+        if ((a.build || a.npm) && !(b.build || b.npm)) {
+          return -1;
+        }
+
+        return b.build || b.npm ? 1 : 0;
+      });
+
+      this.setState({ projects: sortedProjects });
     });
   }
 


### PR DESCRIPTION
Instead of adding a graphical element to cards without build or npm statuses, I tried sorting them last. It works okay with the current number of repos on a 15" laptop screen

![image](https://user-images.githubusercontent.com/13281350/50666088-78b1ed80-0fb3-11e9-82a5-3a58146b4df7.png)
